### PR TITLE
spec: remove nethserver-mail-server dependecy

### DIFF
--- a/nethserver-hylafax.spec
+++ b/nethserver-hylafax.spec
@@ -8,7 +8,6 @@ Source: %{name}-%{version}.tar.gz
 Packager: Giacomo Sanchietti <giacomo.sanchietti@nethesis.it>
 BuildArch: noarch
 Requires: hylafax >= hylafax-5.5.0, urw-fonts, perl-Mail-Sendmail, enscript
-Requires: nethserver-mail-server
 BuildRequires: nethserver-devtools
 
 %description


### PR DESCRIPTION
Mail2fax function will be automatically enabled on
nethserver-mail-server install.

NethServer/dev#5468
